### PR TITLE
using webcomponents to import header

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,0 +1,54 @@
+<template>
+  <header class="sticky-bar">
+    <div class="bottom-header">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-4 col-xs-6">
+            <div class="logotext"><a href="index.html">Madison Invasion</a></div>
+          </div>
+          <div class="col-md-8 col-xs-6">
+          <nav class="main-nav">
+            <div class="responsive-menu"><i class="fa fa-bars"></i></div>
+            <ul>
+              <li><a href="index.html">Home</a></li>
+              <li><a href="#">Info</a>
+                <ul>
+                  <li><a href="instructors.html">Instructors</a></li>
+                  <li><a href="classes.html">Classes</a></li>
+                  <li><a href="comps.html">Competitions</a></li>
+                  <li><a href="music.html">Music</a></li>
+                  <li><a href="pricing.html">Pricing</a></li>
+                  <li><a href="schedule.html">Schedule</a></li>
+                  <li><a href="venues.html">Venues &amp; Parking</a></li>
+                  <li><a href="accom.html">Accommodations</a></li>
+                  <li><a href="faq.html">FAQ</a></li>
+                </ul>
+              </li>
+              
+              <li><a href="contact.html">Contact</a></li>
+              <li><a href="donate.html">Donate</a></li>
+              <li><a href="http://madisoninvasion2017.dancecamps.org/booking.php" target="_blank">Register</a></li>
+            </ul>
+          </nav>
+        </div>
+        </div>
+      </div>
+    </div>
+  </header>
+</template>
+
+<script>
+(function() {
+  const elementTag = 'header-element'; // name of the tag
+  const importDoc = document.currentScript.ownerDocument; // importee
+  class HeaderElement extends HTMLElement {
+    constructor() {
+      super();
+      const template = importDoc.querySelector('template'); // get template in import
+      const clone = document.importNode(template.content, true); // import template
+      document.querySelector(elementTag).appendChild(clone);
+    }
+  }
+  window.customElements.define(elementTag, HeaderElement);
+})()
+</script>

--- a/index.html
+++ b/index.html
@@ -23,48 +23,15 @@
   ga('send', 'pageview');
 
 </script>
+<script src="https://cdn.rawgit.com/webcomponents/webcomponentsjs/v1.0.1/webcomponents-loader.js" type="text/javascript"></script>
+<link rel="import" href="header.html">
 </head>
 <body class="homepage">
 <!-- start site image -->
 <div class="site-image home-img">
 <!-- start header -->
-            <header class="sticky-bar">
-    <div class="bottom-header">
-      <div class="container">
-        <div class="row">
-          <div class="col-md-4 col-xs-6">
-            <div class="logotext"><a href="index.html">Madison Invasion</a></div>
-          </div>
-          <div class="col-md-8 col-xs-6">
-          <nav class="main-nav">
-            <div class="responsive-menu"><i class="fa fa-bars"></i></div>
-            <ul>
-              <li><a href="index.html">Home</a></li>
-              <li><a href="#">Info</a>
-                <ul>
-                  <li><a href="instructors.html">Instructors</a></li>
-                  <li><a href="classes.html">Classes</a></li>
-                  <li><a href="comps.html">Competitions</a></li>
-                  <li><a href="music.html">Music</a></li>
-                  <li><a href="pricing.html">Pricing</a></li>
-                  <li><a href="schedule.html">Schedule</a></li>
-                  <li><a href="venues.html">Venues &amp; Parking</a></li>
-                  <li><a href="accom.html">Accommodations</a></li>
-                  <li><a href="faq.html">FAQ</a></li>
-                </ul>
-              </li>
-              
-              <li><a href="contact.html">Contact</a></li>
-              <li><a href="donate.html">Donate</a></li>
-              <li><a href="http://madisoninvasion2017.dancecamps.org/booking.php" target="_blank">Register</a></li>
-            </ul>
-          </nav>
-        </div>
-        </div>
-      </div>
-    </div>
-  </header>
-            <!-- end header -->
+<header-element></header-element>
+<!-- end header -->
 
 
 <!-- slider -->

--- a/js/options.js
+++ b/js/options.js
@@ -76,14 +76,6 @@ jQuery(document).ready(function () {
     jQuery(function() {
         if(jQuery('.sticky-bar').length) {
             jQuery(".sticky-bar").sticky({topSpacing:0, zIndex:200})
-			.on('sticky-start', function () {
-				jQuery('.logo').css('display', 'none');
-				jQuery('.logotext').css('display', '');
-			})
-			.on('sticky-end', function () {
-				jQuery('.logo').css('display', '');
-				jQuery('.logotext').css('display', 'none');
-			});
         }
     });
 


### PR DESCRIPTION
Pulled the header out to header.html. Also removed the messing around with .logotext that caused it to disappear when you scrolled back up.

All you need to do to use on other pages: add webcomponents loader, add link import, and replace header with header-element.

Note: we're using HTML Templates, Imports, and Custom Elements v1 from Web Components, but specifically not Shadow DOM. I don't have my mind wrapped around that, and it was messing up the css when I tried it.